### PR TITLE
generate-types: Fix canBeOptional computation in parseSignature

### DIFF
--- a/generate-types/index.js
+++ b/generate-types/index.js
@@ -1545,7 +1545,7 @@ const printError = (diagnostic) => {
 							code: getCode(arg.type, innerTypeArgs),
 							optional: false,
 					  };
-				canBeOptional = canBeOptional || optional;
+				canBeOptional = canBeOptional && optional;
 				return `${arg.spread ? "..." : ""}${arg.name}${
 					optional ? "?" : ""
 				}: ${code}`;


### PR DESCRIPTION
A parameter can be optional if *all* of the following parameters are optional.

This fixes several instances of “error TS1016: A required parameter cannot follow an optional parameter” if you try to regenerate the types for webpack with `strictNullChecks` enabled.