### PR TITLE
fix: allow `link` property in schema

### DIFF
--- a/schemas-lint/index.js
+++ b/schemas-lint/index.js
@@ -48,6 +48,7 @@ for (const filename of schemas) {
 			"instanceof",
 			"tsType",
 			"not",
+			"link"
 		];
 
 		const isReference = (schema) => {


### PR DESCRIPTION
`link` property was recently added in the schema.

https://github.com/webpack/schema-utils/pull/133

Also needed to fix lint for https://github.com/webpack/webpack/pull/13822