### PR TITLE
Add line breaks to precompiled schemas so that git can merge changes in the output

### DIFF
--- a/precompile-schemas/index.js
+++ b/precompile-schemas/index.js
@@ -8,6 +8,7 @@ const glob = require("glob");
 const findCommonDir = require("commondir");
 const { pathToFileURL, fileURLToPath } = require("url");
 const processSchema = require("../lib/process-schema");
+const prettier = require("prettier");
 const terser = require("terser");
 const { default: Ajv, _, Name } = require("ajv");
 const standaloneCode = require("ajv/dist/standalone").default;
@@ -125,6 +126,13 @@ const postprocess = async (code) => {
 			toplevel: true,
 		})
 	).code;
+
+	// format to enable diff merging
+	code = prettier.format(code, {
+		parser: "typescript",
+		printWidth: 200,
+		tabWidth: 0,
+	});
 
 	// banner
 	code = `/*


### PR DESCRIPTION
Currently the output is a single line which means at every single change in the WebpackOptions.check.js file is a conflict and needs manual rebase.

This PR applies `prettier` to the minified output, resulting in still mangled code, but split in lines that git should be able to handle.

![image](https://user-images.githubusercontent.com/8700285/147096100-0882f92d-ab2c-4377-9767-f251d4c05f78.png)
