### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/format-file-header/index.js
+++ b/format-file-header/index.js
@@ -151,7 +151,7 @@ for (const filePath of allFiles) {
 			const update = current.update(...match);
 			if (update !== match[0]) {
 				newContent =
-					newContent.substr(0, pos) +
+					newContent.slice(0, pos) +
 					update +
 					newContent.slice(pos + match[0].length);
 				pos += update.length;

--- a/inherit-types/index.js
+++ b/inherit-types/index.js
@@ -135,9 +135,9 @@ for (const sourceFile of program.getSourceFiles()) {
 				});
 				for (const update of updates) {
 					fileContent =
-						fileContent.substr(0, update.start) +
+						fileContent.slice(0, update.start) +
 						update.content +
-						fileContent.substr(update.end);
+						fileContent.slice(update.end);
 				}
 				console.log(`${file} ${updates.length} JSDoc comments added/updated`);
 				fs.writeFileSync(file, fileContent, "utf-8");


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

### Breaking Changes

None

### Additional Info
