### PR TITLE
chore: upgrade prettier to v3

### DIFF
--- a/compile-to-definitions/index.js
+++ b/compile-to-definitions/index.js
@@ -14,15 +14,6 @@ const glob = require("glob");
 const findCommonDir = require("commondir");
 const { compile } = require("json-schema-to-typescript");
 
-const prettierConfig = prettier.resolveConfig.sync(
-	path.resolve(root, outputFolder, "result.d.ts")
-);
-const style = {
-	printWidth: prettierConfig.printWidth,
-	useTabs: prettierConfig.useTabs,
-	tabWidth: prettierConfig.tabWidth,
-};
-
 const makeSchemas = () => {
 	const schemas = glob.sync(schemasGlob, { cwd: root, absolute: true });
 	const commonDir = path.resolve(findCommonDir(schemas));
@@ -31,7 +22,7 @@ const makeSchemas = () => {
 	}
 };
 
-const makeDefinitionsForSchema = (absSchemaPath, schemasDir) => {
+const makeDefinitionsForSchema = async (absSchemaPath, schemasDir) => {
 	if (path.basename(absSchemaPath).startsWith("_")) return;
 	const relPath = path.relative(schemasDir, absSchemaPath);
 	const directory = path.dirname(relPath);
@@ -44,6 +35,16 @@ const makeDefinitionsForSchema = (absSchemaPath, schemasDir) => {
 	const schema = JSON.parse(fs.readFileSync(absSchemaPath, "utf-8"));
 	const keys = Object.keys(schema);
 	if (keys.length === 1 && keys[0] === "$ref") return;
+
+	const prettierConfig = await prettier.resolveConfig(
+		path.resolve(root, outputFolder, "result.d.ts")
+	);
+	const style = {
+		printWidth: prettierConfig.printWidth,
+		useTabs: prettierConfig.useTabs,
+		tabWidth: prettierConfig.tabWidth,
+	};
+
 	preprocessSchema(schema);
 	compile(schema, basename, {
 		bannerComment:

--- a/format-schemas/index.js
+++ b/format-schemas/index.js
@@ -186,7 +186,7 @@ const processJson = processSchema.bind(null, {
 	},
 });
 
-const formatSchema = (schemaPath) => {
+const formatSchema = async (schemaPath) => {
 	const json = require(schemaPath);
 	const processedJson = processJson(json, {
 		schema: json,
@@ -194,8 +194,8 @@ const formatSchema = (schemaPath) => {
 		importPrefix: "../".repeat(schemaPath.split(/[\\/]/).length - minSlashes),
 	});
 	const rawString = JSON.stringify(processedJson, null, 2);
-	const config = prettier.resolveConfig.sync(schemaPath);
-	const prettyString = prettier.format(rawString, config);
+	const config = await prettier.resolveConfig(schemaPath);
+	const prettyString = await prettier.format(rawString, config);
 	let normalizedContent = "";
 	try {
 		const content = fs.readFileSync(schemaPath, "utf-8");

--- a/generate-types/index.js
+++ b/generate-types/index.js
@@ -2349,7 +2349,7 @@ const printError = (diagnostic) => {
 			return;
 		}
 
-		source = prettier.format(source, prettierOptions);
+		source = await prettier.format(source, prettierOptions);
 	} catch (e) {
 		exitCode = 1;
 		console.error(e.message);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@types/node": "^14.14.14",
     "@types/yargs": "^15.0.12",
-    "prettier": "^2.7.1",
+    "prettier": "^3.0.1",
     "typescript": "^5.0.4"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -416,10 +416,10 @@ prettier@^2.0.5:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.0.tgz#8a03c7777883b29b37fb2c4348c66a78e980418b"
   integrity sha512-yYerpkvseM4iKD/BXLYUkQV5aKt4tQPqaGW6EsZjzyu0r7sVZZNPJW4Y8MyKmicp6t42XUPcBVA+H6sB3gqndw==
 
-prettier@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
-  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+prettier@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.1.tgz#65271fc9320ce4913c57747a70ce635b30beaa40"
+  integrity sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==
 
 punycode@^2.1.0:
   version "2.1.1"


### PR DESCRIPTION
- Upgrade prettier.
- [Move to async API ](https://prettier.io/blog/2023/07/05/3.0.0.html#change-public-apis-to-asynchronous-12574httpsgithubcomprettierprettierpull12574-12788httpsgithubcomprettierprettierpull12788-12790httpsgithubcomprettierprettierpull12790-13265httpsgithubcomprettierprettierpull13265-by-fiskerhttpsgithubcomfisker)