### PR TITLE
fix: Normalize urls in precompile-schemas

### DIFF
--- a/precompile-schemas/index.js
+++ b/precompile-schemas/index.js
@@ -18,7 +18,7 @@ const ajv = new Ajv({
 	strictNumbers: false,
 	logger: false,
 	loadSchema: (uri) => {
-		schemaPath = fileURLToPath(uri);
+		schemaPath = fileURLToPath(new URL(decodeURI(uri)));
 		const schema = require(schemaPath);
 		const processedSchema = processJson(schema);
 		processedSchema.$id = uri;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Tests are failing in the webpack repository on Windows because `URL normalization` is not occurring.

<!-- In addition to that, please answer these questions: -->

**What kind of change does this PR introduce?**
fix: normalize the `URL `in precompile-schemes

**Did you add tests for your changes?**
no

**Does this PR introduce a breaking change?**
no

discussion on Discord -> https://discord.com/channels/1180618526436888586/1180619658307571843/1475119754061811936