### PR TITLE
fix(generate-types): preserve infer inside tuple types in extends clause

### DIFF
--- a/generate-types/index.js
+++ b/generate-types/index.js
@@ -2397,6 +2397,39 @@ const printError = (diagnostic) => {
 						return symbol ? symbol.getName() : getCode(t, typeArgs, state);
 					}
 
+					// Tuples in `extends` position must be rendered element-wise so that
+					// `infer` in an element/rest slot survives (getCode collapses it).
+					const objectFlags =
+						t.flags & ts.TypeFlags.Object
+							? /** @type {ts.ObjectType} */ (t).objectFlags
+							: 0;
+					if (objectFlags & ts.ObjectFlags.Reference) {
+						const target = /** @type {ts.TypeReference} */ (t).target;
+						if (
+							target &&
+							/** @type {ts.ObjectType} */ (target).objectFlags &
+								ts.ObjectFlags.Tuple
+						) {
+							const tupleTarget = /** @type {ts.TupleType} */ (target);
+							const elements = checker.getTypeArguments(
+								/** @type {ts.TypeReference} */ (t),
+							);
+							const parts = elements.map((el, i) => {
+								const flag = tupleTarget.elementFlags[i];
+								const inner = getExtendsString(el);
+								// Rest `...x[]` carries the element type; Variadic `...x`
+								// (incl. `...infer R`) carries the whole spread type.
+								if (flag & ts.ElementFlags.Rest) return `...(${inner})[]`;
+								if (flag & ts.ElementFlags.Variadic) return `...${inner}`;
+								if (flag & ts.ElementFlags.Optional) return `${inner}?`;
+								return inner;
+							});
+							return `${tupleTarget.readonly ? "readonly " : ""}[${parts.join(
+								", ",
+							)}]`;
+						}
+					}
+
 					if (checker.isArrayType(t)) {
 						const elementType = t.typeArguments[0];
 						return "(" + getExtendsString(elementType) + ")[]";


### PR DESCRIPTION
**Summary**

`generate-types` dropped the `infer` keyword when a conditional type's `extends` clause used `infer` inside a tuple element/rest slot (e.g. `T extends readonly [infer H, ...any[]]`), collapsing `infer H`/`...infer R` to free references `H`/`R` and emitting invalid `types.d.ts` (`TS2304: Cannot find name 'H'/'R'`). `getExtendsString` handled `infer` in type-parameter and array positions but not tuples. This renders tuples in `extends` position element-wise so `infer` survives, honoring rest/variadic/optional element flags and the `readonly` modifier.

Closes https://github.com/webpack/webpack/issues/21191

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

No — `tooling` has no test harness for `generate-types`; verified by running `generate-types` against a fixture with the issue's `Head`/`Tail` typedefs (output now emits `infer H`/`...infer R` and passes `tsc --strict`, whereas the old output failed with TS2304) and confirmed by regenerating webpack's `types.d.ts` in webpack/webpack#21201.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a

**Use of AI**

AI (Claude) was used to apply and verify the fix (fixture-based round-trip plus `tsc`); reviewed before committing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQY5YCiFG6wzH8zQqV3S53)_